### PR TITLE
Improve Python syntax highlighting

### DIFF
--- a/themes/darcula-solid-color-theme.json
+++ b/themes/darcula-solid-color-theme.json
@@ -1047,7 +1047,7 @@
       "name": "Python types",
       "scope": "support.type.python",
       "settings": {
-        "foreground": "#8888C6"
+        "foreground": "#8ba6c2"
       }
     },
     {
@@ -1061,14 +1061,14 @@
       "name": "Python special functions",
       "scope": "support.function.magic.python",
       "settings": {
-        "foreground": "#B200B2"
+        "foreground": "#FFC66D"
       }
     },
     {
       "name": "Python self",
       "scope": "variable.parameter.function.language.special.self.python,variable.language.special.self.python",
       "settings": {
-        "foreground": "#94558D"
+        "foreground": "#9899bf"
       }
     },
     {
@@ -1078,7 +1078,7 @@
         "source.python meta.function.decorator.python support.type.python"
       ],
       "settings": {
-        "foreground": "#BBB529"
+        "foreground": "#ffc66d"
       }
     }
   ]

--- a/themes/darcula-solid-color-theme.json
+++ b/themes/darcula-solid-color-theme.json
@@ -1056,6 +1056,13 @@
       "settings": {
         "foreground": "#AA4926"
       }
+    },
+    {
+      "name": "Python special functions",
+      "scope": "support.function.magic.python",
+      "settings": {
+        "foreground": "#B200B2"
+      }
     }
   ]
 }

--- a/themes/darcula-solid-color-theme.json
+++ b/themes/darcula-solid-color-theme.json
@@ -1063,6 +1063,13 @@
       "settings": {
         "foreground": "#B200B2"
       }
+    },
+    {
+      "name": "Python self",
+      "scope": "variable.parameter.function.language.special.self.python,variable.language.special.self.python",
+      "settings": {
+        "foreground": "#94558D"
+      }
     }
   ]
 }

--- a/themes/darcula-solid-color-theme.json
+++ b/themes/darcula-solid-color-theme.json
@@ -1049,6 +1049,13 @@
       "settings": {
         "foreground": "#8888C6"
       }
+    },
+    {
+      "name": "Python parameters",
+      "scope": "variable.parameter.function-call.python",
+      "settings": {
+        "foreground": "#AA4926"
+      }
     }
   ]
 }

--- a/themes/darcula-solid-color-theme.json
+++ b/themes/darcula-solid-color-theme.json
@@ -1070,6 +1070,16 @@
       "settings": {
         "foreground": "#94558D"
       }
+    },
+    {
+      "name": "Python annotation",
+      "scope": [
+        "punctuation.definition.decorator.python",
+        "source.python meta.function.decorator.python support.type.python"
+      ],
+      "settings": {
+        "foreground": "#BBB529"
+      }
     }
   ]
 }

--- a/themes/darcula-solid-color-theme.json
+++ b/themes/darcula-solid-color-theme.json
@@ -1042,6 +1042,13 @@
       "settings": {
         "foreground": "#FFC66D"
       }
+    },
+    {
+      "name": "Python types",
+      "scope": "support.type.python",
+      "settings": {
+        "foreground": "#8888C6"
+      }
     }
   ]
 }

--- a/themes/darcula-solid-color-theme.json
+++ b/themes/darcula-solid-color-theme.json
@@ -1051,13 +1051,6 @@
       }
     },
     {
-      "name": "Python parameters",
-      "scope": "variable.parameter.function-call.python",
-      "settings": {
-        "foreground": "#AA4926"
-      }
-    },
-    {
       "name": "Python special functions",
       "scope": "support.function.magic.python",
       "settings": {


### PR DESCRIPTION
This pull request improves syntax highlighting for Python language.

What was changed:

1. Types color:

   ```python
   def foo(a: int) -> float:
              ^^^     ^^^^^
              here    here
   ```
   
2. Parameters color:

   ```python
   def foo(a: int):
       pass

   foo(a=5)
       ^
      here
   ```

3. Special functions color (`__init__`, `__str__`, `__repr__` etc.)

4. `self` keyword color

5. Decorators color:

   ```python
   class Foo:
       @staticmethod
       ^^^^^^^^^^^^^
           here
       def static_method():
           pass
   ```

All colors were taken from the PyCharm 2023.2 classic UI color theme.

Before:
![Screenshot_20230729_204913](https://github.com/jussiemion/darcula-solid/assets/35779485/8de7f0cf-e71f-4bd9-a759-57c30d149800)

After:
![Screenshot_20230729_204820](https://github.com/jussiemion/darcula-solid/assets/35779485/a0f66d41-26d0-49b6-a55e-6eba4eadc7fc)
